### PR TITLE
Fix theme toggle visibility over header

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
       cursor: pointer;
       box-shadow: 0 2px 5px rgba(0,0,0,0.2);
       transition: transform 0.2s, background 0.3s;
+      z-index: 10;
     }
 
     #theme-toggle:hover {


### PR DESCRIPTION
## Summary
- keep the dark/light theme button visible above the header

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6873fcc3568483329f92a3a0d3bacbf9